### PR TITLE
Add compatiblity for TYPO3 7.6

### DIFF
--- a/ec_styla/Classes/Compatiblity/_7_6/Utility/StylaRequest.php
+++ b/ec_styla/Classes/Compatiblity/_7_6/Utility/StylaRequest.php
@@ -1,0 +1,101 @@
+<?php
+
+/****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 entwicklung@ecentral.de <entwicklung@ecentral.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+
+namespace Ecentral\EcStyla\Compatiblity\_7_6\Utility;
+
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Http\HttpRequest;
+
+/**
+ * Class StylaRequest
+ * @package Ecentral\EcStyla\Compatiblity\_7_6\Utility
+ */
+class StylaRequest
+{
+    protected $logger;
+    protected $cachePeriod = 0;
+
+    public function get($url)
+    {
+        /** @var \TYPO3\CMS\Core\Log\Logger $logger */
+        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
+
+        /** @var HttpRequest $request */
+        $request = GeneralUtility::makeInstance(HttpRequest::class);
+
+        try {
+            $request->setUrl($url);
+            $request->setConfig('follow_redirects', true);
+            $request->setMethod(\HTTP_Request2::METHOD_GET);
+
+            $response = $request->send();
+
+            if (true == isset($response) && 200 === $response->getStatus()) {
+                $content = json_decode($response->getBody());
+                if (null !== $content &&
+                    strtolower($content->code) === 'success') {
+                    $cacheControl = $response->getHeader('cache-control');
+
+                    if (null !== $cacheControl) {
+                        $this->cachePeriod = $cacheControl;
+                    }
+
+                    return $content;
+                } else {
+                    $this->logger->error(
+                        'Styla api could not deliver requested content',
+                        array(
+                            'code' => $content->code,
+                        )
+                    );
+                }
+            } else {
+                throw new \HTTP_Request2_Exception("Unexpected response status: " . $response->getStatus());
+            }
+        } catch (\HTTP_Request2_Exception $e) {
+            $this->logger->error(
+                'Exception during communication with styla api',
+                array(
+                    'url' => $url,
+                    'page' => $GLOBALS['TSFE']->id,
+                    'message' => $e->getMessage()
+                )
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCachePeriod()
+    {
+        return $this->cachePeriod;
+    }
+}

--- a/ec_styla/Classes/Utility/StylaRequest.php
+++ b/ec_styla/Classes/Utility/StylaRequest.php
@@ -1,0 +1,91 @@
+<?php
+
+/****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 entwicklung@ecentral.de <entwicklung@ecentral.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+namespace Ecentral\EcStyla\Utility;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Http\RequestFactory;
+
+/**
+ * Class StylaRequest
+ * @package Ecentral\EcStyla\Utility
+ */
+class StylaRequest implements LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    protected $cachePeriod = 0;
+
+    public function get($url)
+    {
+        /** @var RequestFactory $requestFactory */
+        $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
+
+        $response = $requestFactory->request($url, 'GET', array('allow_redirects' => true));
+        if ($response->getStatusCode() === 200) {
+            $content = json_decode($response->getBody()->getContents());
+            if (null !== $content &&
+                strtolower($content->code) === 'success') {
+
+                if (null != ($cacheControl = $response->getHeader('cache-control'))) {
+                    $this->cachePeriod = $cacheControl;
+                }
+
+                return $content;
+            } else {
+                $this->logger->error(
+                    'Styla api could not deliver the requested content',
+                    array(
+                        'code' => $content->code,
+                    )
+                );
+            }
+        } else {
+            $this->logger->error(
+                'Error during communication with styla api',
+                array(
+                    'url' => $url,
+                    'page' => $GLOBALS['TSFE']->id,
+                    'status' => $response->getStatusCode()
+                )
+            );
+
+            return null;
+        }
+    }
+
+    /**
+     * Return cache period
+     *
+     * @return int
+     */
+    public function getCachePeriod()
+    {
+        return $this->cachePeriod;
+    }
+}

--- a/ec_styla/ext_emconf.php
+++ b/ec_styla/ext_emconf.php
@@ -37,7 +37,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.2',
     'constraints' => [
         'depends' => [
-            'typo3' => '8.7.0-8.7.99',
+            'typo3' => '7.6.32-8.7.99',
             'realurl' => '2.0.0-2.9.99'
         ],
         'conflicts' => [],

--- a/ec_styla/ext_localconf.php
+++ b/ec_styla/ext_localconf.php
@@ -103,5 +103,12 @@ call_user_func(
         if (false == isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ec_styla']['frontend'])) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ec_styla']['frontend'] = \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class;
         }
+
+        if ('7.6' == TYPO3_branch) {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['Ecentral\\EcStyla\\Utility\\StylaRequest'] = array(
+                'className' => '\Ecentral\EcStyla\Compatiblity\_7_6\Utility\StylaRequest::class'
+            );
+        }
+
     }
 );

--- a/ec_styla/ext_localconf.php
+++ b/ec_styla/ext_localconf.php
@@ -106,7 +106,7 @@ call_user_func(
 
         if ('7.6' == TYPO3_branch) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['Ecentral\\EcStyla\\Utility\\StylaRequest'] = array(
-                'className' => '\Ecentral\EcStyla\Compatiblity\_7_6\Utility\StylaRequest::class'
+                'className' => \Ecentral\EcStyla\Compatiblity\_7_6\Utility\StylaRequest::class
             );
         }
 


### PR DESCRIPTION
By using HTTP_Request2 instead of GuzzleHttp wrapper on 7.6 installations
