### PR TITLE
Feature/typoscript integration

### DIFF
--- a/Classes/Controller/ContentHubController.php
+++ b/Classes/Controller/ContentHubController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Ecentral\EcStyla\Controller;
 
+use TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /***************************************************************
@@ -64,6 +65,18 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
      */
     public function showAction()
     {
+        if (!array_key_exists('api_url',$this->settings)
+            || !array_key_exists('contenthub_segment',$this->settings)) {
+            $pluginConfigFromSetup = '';
+            TypoScriptParser::includeFile('typo3conf/ext/ec_styla/Configuration/TypoScript/setup.ts' ,1 ,false,$pluginConfigFromSetup);
+            /** @var TypoScriptParser $typoScriptParser */
+            $typoScriptParser = $this->objectManager->get(TypoScriptParser::class);
+            $typoScriptParser->parse($pluginConfigFromSetup);
+            $this->settings['api_url'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['api_url'];
+            $this->settings['contenthub_segment'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['contenthub_segment'];
+            $this->settings['disabled_meta_tags'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['disabled_meta_tags'];
+        }
+
         $this->cache = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('ec_styla');
         $cacheIdentifier = $this->getCacheIdentifier();
         $cachedContent = $this->cache->get($cacheIdentifier);

--- a/Classes/Controller/ContentHubController.php
+++ b/Classes/Controller/ContentHubController.php
@@ -78,7 +78,6 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
             $typoScriptParser = $this->objectManager->get(TypoScriptParser::class);
             $typoScriptParser->parse($pluginConfigFromSetup);
             $this->settings['api_url'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['api_url'];
-            $this->settings['contenthub_segment'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['contenthub_segment'];
         }
 
         $this->cache = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('ec_styla');
@@ -132,7 +131,6 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
                 $GLOBALS['TSFE']->additionalHeaderData[] = $headerElement;
             }
         }
-
         $this->view->assign('seoHtml', $content->html->body);
     }
 

--- a/Classes/Controller/ContentHubController.php
+++ b/Classes/Controller/ContentHubController.php
@@ -42,6 +42,11 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
     protected $cache;
 
     /**
+     * @var array
+     */
+    protected $disabledMetaTagsArray = [];
+
+    /**
      * Default lifetime of cached data
      * @var int
      */
@@ -118,6 +123,8 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
             return;
         }
 
+        $this->disabledMetaTagsArray = array_map('trim', explode(',', $this->settings['disabled_meta_tags']));
+
         foreach ($content->tags as $item) {
             if ('' != ($headerElement = $this->getHtmlForTagItem($item))) {
                 // If Cache-Control is set to no-cache upon request, the page renderer
@@ -168,7 +175,7 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
     protected function getHtmlForTagItem($item) {
         switch ($item->tag) {
             case 'meta':
-                if(null != $item->attributes->name) {
+                if(null != $item->attributes->name && !in_array($item->attributes->name, $this->disabledMetaTagsArray)) {
                     return '<meta name="' . $item->attributes->name  . '" content="' . $item->attributes->content . '" />';
                 }
                 return '<meta property="' .  $item->attributes->property  . '" content="' . $item->attributes->content . '" />';

--- a/Classes/Controller/ContentHubController.php
+++ b/Classes/Controller/ContentHubController.php
@@ -79,7 +79,6 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
             $typoScriptParser->parse($pluginConfigFromSetup);
             $this->settings['api_url'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['api_url'];
             $this->settings['contenthub_segment'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['contenthub_segment'];
-            $this->settings['disabled_meta_tags'] = $typoScriptParser->setup['plugin.']['tx_ecstyla_contenthub.']['settings.']['disabled_meta_tags'];
         }
 
         $this->cache = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('ec_styla');
@@ -178,7 +177,10 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
                 if(null != $item->attributes->name && !in_array($item->attributes->name, $this->disabledMetaTagsArray)) {
                     return '<meta name="' . $item->attributes->name  . '" content="' . $item->attributes->content . '" />';
                 }
-                return '<meta property="' .  $item->attributes->property  . '" content="' . $item->attributes->content . '" />';
+                if (!in_array($item->attributes->property, $this->disabledMetaTagsArray)) {
+                    return '<meta property="' .  $item->attributes->property  . '" content="' . $item->attributes->content . '" />';
+                }
+                return '';
                 break;
             case 'link':
                 return '<link rel="' . $item->attributes->rel . '" href="' . $item->attributes->href . '" />';
@@ -189,5 +191,10 @@ class ContentHubController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
             default:
                 return '';
         }
+    }
+
+    protected function removeTYPO3MetaTags() {
+        $metaTagManager = $this->objectManager->get(MetaManagrw::class)->getManagerForProperty('og:title');
+
     }
 }

--- a/Classes/Hook/Realurl.php
+++ b/Classes/Hook/Realurl.php
@@ -55,13 +55,15 @@ class Realurl implements SingletonInterface {
      */
     public function configure($parameters) {
 
-        $uriSegment = $this->getExtensionConfiguration('rootPath');
+        $uriSegments = array_map('trim', explode(',', $this->getExtensionConfiguration('rootPath')));
 
         $signalSlotDispatcher = $this->objectManager->get(Dispatcher::class);
-        list($uriSegment) = $signalSlotDispatcher->dispatch(__CLASS__, 'beforeCheckingForRootPath', array($uriSegment));
+        foreach ($uriSegments as $uriSegment) {
+            list($uriSegment) = $signalSlotDispatcher->dispatch(__CLASS__, 'beforeCheckingForRootPath', array($uriSegment));
 
-        if ($this->isStylaRequest($uriSegment)) {
-            $parameters['configuration']['init']['postVarSet_failureMode'] = 'ignore';
+            if ($this->isStylaRequest($uriSegment)) {
+                $parameters['configuration']['init']['postVarSet_failureMode'] = 'ignore';
+            }
         }
     }
 

--- a/Configuration/FlexForms/ContentHub.xml
+++ b/Configuration/FlexForms/ContentHub.xml
@@ -15,6 +15,14 @@
                             </config>
                         </TCEforms>
                     </settings.contenthub.id>
+                    <settings.contenthub.stylaContent>
+                        <TCEforms>
+                            <label>LLL:EXT:ec_styla/Resources/Private/Language/locallang.xlf:tx_ecstyla_domain_model_contenthub.styla_content</label>
+                            <config>
+                                <type>input</type>
+                            </config>
+                        </TCEforms>
+                    </settings.contenthub.stylaContent>
                 </el>
             </ROOT>
         </sDEF>

--- a/Configuration/TypoScript/constants.ts
+++ b/Configuration/TypoScript/constants.ts
@@ -12,4 +12,8 @@ plugin.tx_ecstyla_contenthub {
         # cat=plugin.tx_ecstyla_contenthub//a; type=string; label=Default storage PID
         storagePid =
     }
+    settings {
+    # cat=plugin.tx_ecstyla_contenthub/settings/meta; type=string; label=Meta Tags that should be disabled for styla
+        disabled_meta_tags = 
+    }
 }

--- a/Configuration/TypoScript/setup.ts
+++ b/Configuration/TypoScript/setup.ts
@@ -25,5 +25,6 @@ plugin.tx_ecstyla_contenthub {
     settings {
         contenthub_segment = magazine
         api_url = https://seoapi.styla.com/clients/
+        disabled_meta_tags =
     }
 }

--- a/Configuration/TypoScript/setup.ts
+++ b/Configuration/TypoScript/setup.ts
@@ -23,7 +23,6 @@ plugin.tx_ecstyla_contenthub {
         #callDefaultActionIfActionCantBeResolved = 1
     }
     settings {
-        contenthub_segment = magazine
         api_url = https://seoapi.styla.com/clients/
         disabled_meta_tags = {$plugin.tx_ecstyla_contenthub.settings.disabled_meta_tags}
     }

--- a/Configuration/TypoScript/setup.ts
+++ b/Configuration/TypoScript/setup.ts
@@ -25,6 +25,6 @@ plugin.tx_ecstyla_contenthub {
     settings {
         contenthub_segment = magazine
         api_url = https://seoapi.styla.com/clients/
-        disabled_meta_tags =
+        disabled_meta_tags = {$plugin.tx_ecstyla_contenthub.settings.disabled_meta_tags}
     }
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ MySQL >= 5.5
 Within the extension configuration (Admin Tools->Extensions->Ecentral Styla Integration) the rootpath to the Styla content needs to be set up. By default, this is set to `magazine` which is the default Styla content hub integration.
 
 ### Root Page Configuration
-If you want to use something else than the default configuration, you can include the Typoscript template 'Styla Integration (ec_styla)' to your root page template (via Web->List->Your Root Page). Options can be configured for either the whole pagetree or the individual pages. 
+If you want to use something else than the default configuration, you can configure the extension to use other root paths. To do this, go to the extension configuration and edit the configuration of ec_styla. Enter every path, where the styla content hub plugin should be displayed, separated by commas.
 
 ### Content Page Configuration
 Necessary meta elements are provided by Styla. This configuration has to be

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ MySQL >= 5.5
 ## Configuration
 
 ### Extension Configuration
-Within the extension configuration (Admin Tools->Extensions->Ecentral Styla Integration) the rootpath to the Styla content needs to be set up. By default, this is set to `magazine` which is the default Styla content hub integration.
+Within the extension configuration (Admin Tools->Extensions->Ecentral Styla Integration) the rootpath to the Styla content needs to be set up. By default, this is set to `magazine` which is the default Styla content integration.
 
 ### Root Page Configuration
-If you want to use something else than the default configuration, you can configure the extension to use other root paths. To do this, go to the extension configuration and edit the configuration of ec_styla. Enter every path, where the styla content hub plugin should be displayed, separated by commas.
+If you want to use something else than the default configuration, you can configure the extension to use other root paths. To do this, go to the extension configuration and edit the configuration of ec_styla. Enter every path, where the styla content plugin should be displayed, separated by commas.
 
 ### Content Page Configuration
 Necessary meta elements are provided by Styla. This configuration has to be

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ MySQL >= 5.5
 Within the extension configuration (Admin Tools->Extensions->Ecentral Styla Integration) the rootpath to the Styla content needs to be set up. By default, this is set to `magazine` which is the default Styla content hub integration.
 
 ### Root Page Configuration
-Include the Typoscript template 'Styla Integration (ec_styla)' to your root page template (via Web->List->Your Root Page). You may use the provided
-default or set your own configuration. Options can be configured for either the whole pagetree or the individual pages. 
+If you want to use something else than the default configuration, you can include the Typoscript template 'Styla Integration (ec_styla)' to your root page template (via Web->List->Your Root Page). Options can be configured for either the whole pagetree or the individual pages. 
 
 ### Content Page Configuration
 Necessary meta elements are provided by Styla. This configuration has to be
@@ -41,6 +40,8 @@ You can add Styla Plugins via the 'Add Content' option of the page module.
 ### Content Hub
 The content hub plugin will display a single content hub or Styla Landing Page. You only need to provide the content hub id and let Styla do the
 magic. Please make sure the page title corresponds to your `plugin.tx_ecstyla_contenthub.settings.contenthub_segment` setting.
+#### Metadata
+It is possible to disable specific meta tags via the typoscript setup key `plugin.tx_ecstyla_contenthub.settings.disabled_meta_tags`. You can configure multiple tag names and properties by separating them with commas
 
 ### Teaser
 The Teaser plugin allows you to feature a number of stories from your Styla content hub. You can set the number of items 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -15,6 +15,9 @@
 			<trans-unit id="tx_ecstyla_domain_model_contenthub.content_hub_segment">
 				<source>Content Hub Segment</source>
 			</trans-unit>
+			<trans-unit id="tx_ecstyla_domain_model_contenthub.styla_content">
+				<source>Styla Content</source>
+			</trans-unit>
 
 			<trans-unit id="tx_ecstyla_domain_model_teaser.limit">
 				<source>Limit</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -4,7 +4,7 @@
 		<header/>
 		<body>
 			<trans-unit id="tx_ec_styla_contenthub.name">
-				<source>Styla Content Hub</source>
+				<source>Styla Content</source>
 			</trans-unit>
 			<trans-unit id="tx_ec_styla_contenthub.description">
 				<source>Displays stories inside a content hub.</source>

--- a/Resources/Private/Templates/ContentHub/Show.html
+++ b/Resources/Private/Templates/ContentHub/Show.html
@@ -3,7 +3,7 @@
 	<f:layout name="Default" />
 
 	<f:section name="content">
-		<div id="stylaMagazine">
+		<div id="stylaMagazine" data-styla-client="{settings.contenthub.id}" data-styla-content="/magazine">
 			<f:format.raw>{seoHtml}</f:format.raw>
 		</div>
 		<script src="https://client-scripts.styla.com/scripts/clients/{settings.contenthub.id}.js" async></script>

--- a/Resources/Private/Templates/ContentHub/Show.html
+++ b/Resources/Private/Templates/ContentHub/Show.html
@@ -3,7 +3,15 @@
 	<f:layout name="Default" />
 
 	<f:section name="content">
-		<div id="stylaMagazine" data-styla-client="{settings.contenthub.id}" data-styla-content="/magazine">
+
+		<f:if condition="{stylaContent}">
+			<f:then>
+				<div data-styla-client="{settings.contenthub.id}" data-styla-content="{stylaContent}">
+			</f:then>
+			<f:else>
+				<div id="stylaMagazine" data-styla-client="{settings.contenthub.id}" data-styla-content="/magazine">
+			</f:else>
+		</f:if>
 			<f:format.raw>{seoHtml}</f:format.raw>
 		</div>
 		<script src="https://client-scripts.styla.com/scripts/clients/{settings.contenthub.id}.js" async></script>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,4 @@
 # cat=basic; type=string; label=Rootpath
 rootPath = magazine
+# cat=basic; type=boolean; label=Derive Styla content from url
+autodetectContent = 0

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -37,7 +37,7 @@ call_user_func(
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
             'Ecentral.EcStyla',
             'Contenthub',
-            'Styla Content Hub'
+            'Styla Content'
         );
 
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('ec_styla', 'Configuration/TypoScript', 'Styla Integration');


### PR DESCRIPTION
Feature Request: Integrate TypoScript automatically when adding a Content Hub Plugin.

*Use Case*: After the plugin is setup by a TYPO3 administrator, Content editors should be able to use the Styla integration without further support from TYPO3 admins. That means can create simple pages in TYPO3, add the Styla Content Hub plugin but they must not be bothered with adding TypoScript snippets to the page (and they neither have the permission to do so)

*Action*: https://github.com/styladev/typo3#content-page-configuration needs to be handled by the Styla extension automatically. Make sure that the TYPO3 administrator can globally decide which HTML Meta tags are handled by the Styla Integration.